### PR TITLE
Update flake inputs (2026-06-03)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -182,11 +182,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780408569,
+        "narHash": "sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "f384af1bec6423a0d4ba1855917ab948f64e5808",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779604987,
-        "narHash": "sha256-ZQ5z+fVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs+s=",
+        "lastModified": 1780210899,
+        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "8fba98c80b48fa013820e0163c5096922fea4ddd",
+        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780119977,
-        "narHash": "sha256-EL2Z1hhvhkZTeuAWPhcadcrKg/KcJtZ1P8EZiA9Je/U=",
+        "lastModified": 1780438327,
+        "narHash": "sha256-bAFXjxSV3GJLIrxdT1dgwf1QFl2iVVcdbiCq9uEPrhs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e72ac632561496e143ac77a0f0dd44dab14b176f",
+        "rev": "fdd2b25e13ee6f21db830f7fa3f2feadce7d9c9c",
         "type": "github"
       },
       "original": {
@@ -422,11 +422,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/profiles/core/home-manager.nix
+++ b/profiles/core/home-manager.nix
@@ -5,9 +5,11 @@
   ];
 
   home-manager.backupFileExtension = "backup";
-  home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
   home-manager.sharedModules = [
     plasma-manager.homeModules.plasma-manager
+    {
+      nixpkgs.config.allowUnfree = true;
+    }
   ];
 }

--- a/profiles/graphical/steam.nix
+++ b/profiles/graphical/steam.nix
@@ -1,10 +1,7 @@
-{ pkgs, lib, ... }: {
+{ pkgs, ... }: {
   hardware.graphics.enable32Bit = true;
 
   programs.steam = {
     enable = true;
   };
-
-  # Disable setuid for bwrap
-  security.wrappers.bwrap.setuid = lib.mkForce false;
 }

--- a/users/profiles/graphical/gnome/variety/default.nix
+++ b/users/profiles/graphical/gnome/variety/default.nix
@@ -6,7 +6,10 @@
     ];
 
     file = {
-      ".config/autostart/variety.desktop".source = (pkgs.variety + "/share/applications/variety.desktop");
+      ".config/autostart/variety.desktop" = {
+        source = (pkgs.variety + "/share/applications/variety.desktop");
+        force = true;
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary

- Updated flake.lock with `nix flake update` — nixpkgs, home-manager, nix-index-database, nur, treefmt-nix refreshed
- Removed stale `security.wrappers.bwrap.setuid` reference removed in newer nixpkgs
- Removed `home-manager.useGlobalPkgs` and moved `nixpkgs.config.allowUnfree` into `sharedModules` to silence deprecation warning
- Added `force = true` on `variety.desktop` file to prevent backup clobber errors