### PR TITLE
Replace Forge with Tiling Assistant on all hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .direnv
+.kilo
 result

--- a/users/matte.nix
+++ b/users/matte.nix
@@ -17,7 +17,7 @@ in
       imports = [
         ./profiles/graphical/firefox.nix
         ./profiles/graphical/gnome/default.nix
-        ./profiles/graphical/gnome/extensions/forge.nix
+        ./profiles/graphical/gnome/extensions/tiling-assistant.nix
         ./profiles/graphical/gnome/variety/default.nix
         ./profiles/graphical/gnome/variety/bing.nix
         ./profiles/programming/vscode/default.nix

--- a/users/profiles/graphical/gnome/extensions/tiling-assistant.nix
+++ b/users/profiles/graphical/gnome/extensions/tiling-assistant.nix
@@ -1,0 +1,36 @@
+{ lib, pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    gnomeExtensions.tiling-assistant
+  ];
+
+  dconf.settings = {
+    "org/gnome/shell" = {
+      enabled-extensions = [
+        "tiling-assistant@leleat-on-github"
+      ];
+    };
+
+    "org/gnome/shell/extensions/tiling-assistant" = {
+      window-gap = lib.hm.gvariant.mkInt32 5;
+      enable-tiling-popup = true;
+      enable-advanced-experimental-features = true;
+
+      favorite-layouts = [
+        ''{"_name":"3 Equal Columns","_items":[{"rect":{"x":0,"y":0,"width":0.333,"height":1},"appId":null,"loopType":null},{"rect":{"x":0.333,"y":0,"width":0.333,"height":1},"appId":null,"loopType":null},{"rect":{"x":0.666,"y":0,"width":0.333,"height":1},"appId":null,"loopType":null}]}''
+        ''{"_name":"2x16:9 Left + Right","_items":[{"rect":{"x":0,"y":0,"width":0.374,"height":0.5},"appId":null,"loopType":null},{"rect":{"x":0,"y":0.5,"width":0.374,"height":0.5},"appId":null,"loopType":null},{"rect":{"x":0.374,"y":0,"width":0.626,"height":1},"appId":null,"loopType":null}]}''
+      ];
+
+      activate-layout0 = [ "<Super>KP_1" ];
+      activate-layout1 = [ "<Super>KP_2" ];
+    };
+
+    "org/gnome/desktop/wm/keybindings" = {
+      move-to-workspace-left = [ "<Shift><Control><Super>Left" ];
+      move-to-workspace-right = [ "<Shift><Control><Super>Right" ];
+      switch-to-workspace-left = [ "<Control><Super>Left" ];
+      switch-to-workspace-right = [ "<Control><Super>Right" ];
+    };
+  };
+}

--- a/users/profiles/graphical/gnome/extensions/tiling-assistant.nix
+++ b/users/profiles/graphical/gnome/extensions/tiling-assistant.nix
@@ -17,6 +17,10 @@
       enable-tiling-popup = true;
       enable-advanced-experimental-features = true;
 
+      default-move-mode = 2;
+      favorite-layout = 0;
+      show-layout-panel-indicator = true;
+
       favorite-layouts = [
         ''{"_name":"3 Equal Columns","_items":[{"rect":{"x":0,"y":0,"width":0.333,"height":1},"appId":null,"loopType":null},{"rect":{"x":0.333,"y":0,"width":0.333,"height":1},"appId":null,"loopType":null},{"rect":{"x":0.666,"y":0,"width":0.333,"height":1},"appId":null,"loopType":null}]}''
         ''{"_name":"2x16:9 Left + Right","_items":[{"rect":{"x":0,"y":0,"width":0.374,"height":0.5},"appId":null,"loopType":null},{"rect":{"x":0,"y":0.5,"width":0.374,"height":0.5},"appId":null,"loopType":null},{"rect":{"x":0.374,"y":0,"width":0.626,"height":1},"appId":null,"loopType":null}]}''

--- a/users/test.nix
+++ b/users/test.nix
@@ -14,6 +14,7 @@ in
       imports = [
         ./profiles/graphical/firefox.nix
         ./profiles/graphical/gnome/default.nix
+        ./profiles/graphical/gnome/extensions/tiling-assistant.nix
         ./profiles/shell/direnv.nix
         ./profiles/shell/fish.nix
         ./profiles/shell/fzf.nix


### PR DESCRIPTION
## Summary

- Replace Forge with Tiling Assistant on all 3 hosts (ryzen, t14g1, game)
- Enable Tiling Assistant for the test user as well

## Changes

- **`users/profiles/graphical/gnome/extensions/tiling-assistant.nix`** (new) — TA config with:
  - `window-gap 5`, `enable-tiling-popup`, experimental features
  - 2 custom layouts: "3 Equal Columns" and "2×16:9 Left + Right" (with `0.374` resolution-independent width)
  - Keyboard shortcuts `Super+KP_1` / `Super+KP_2` for layout activation
  - `default-move-mode = 2` (drag auto-applies layout), `favorite-layout = 0`, `show-layout-panel-indicator = true`
  - WM workspace keybinding overrides carried over from forge.nix
- **`users/matte.nix`** — import tiling-assistant.nix instead of forge.nix
- **`users/test.nix`** — import tiling-assistant.nix
- **`.gitignore`** — add `.kilo` directory

forge.nix is preserved as dead code (not imported, still in repo).

## Workflow note

Tiling Assistant layouts are **snap-to-zone** (Tiling Popup at each rectangle), not auto-tiling like Forge.