### PR TITLE
docs: add file conventions section to AGENTS.md for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ Public keys in `secrets/secrets.nix`. Currently encrypted: `matte_password`, `ma
 
 VS Code with nixd LSP. Format on save via `nixpkgs-fmt`. nixd uses `nixosConfigurations.ryzen.options` for option completion.
 
+## File conventions
+
+Always ensure every file ends with a trailing newline — `treefmt-check` in CI rejects files that don't.
+
 ## GitHub
 
 Use `gh` (GitHub CLI) for all GitHub operations (issues, PRs, checks, releases). Available in the devshell.


### PR DESCRIPTION
## Summary

- Add a `File conventions` section to `AGENTS.md` instructing AI agents to always ensure files end with a trailing newline
- This prevents `treefmt-check` CI failures caused by missing final newlines