### PR TITLE
feat: add ghostty terminal with GitHub Dark High Contrast theme

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
               ./profiles/graphical/discord.nix
               ./profiles/graphical/gamescope-steam-session.nix
               ./profiles/graphical/gdm.nix
+              ./profiles/graphical/ghostty.nix
               ./profiles/graphical/gnome.nix
               ./profiles/graphical/libreoffice.nix
               ./profiles/graphical/logitechg29.nix
@@ -111,10 +112,12 @@
               ./profiles/graphical/discord.nix
               ./profiles/graphical/gamescope-steam-session.nix
               ./profiles/graphical/gdm.nix
+              ./profiles/graphical/ghostty.nix
               ./profiles/graphical/gnome.nix
               ./profiles/graphical/libreoffice.nix
               ./profiles/graphical/spotify.nix
               ./profiles/graphical/steam.nix
+
               ./profiles/remotefs/sshfs/ds920.nix
               ./profiles/shells/core.nix
               ./profiles/shells/fish.nix
@@ -132,6 +135,7 @@
               ./profiles/boot/systemd-boot.nix
               ./profiles/core/default.nix
               ./profiles/core/cachix-deploy.nix
+              ./profiles/graphical/ghostty.nix
               ./profiles/graphical/gnome.nix
               ./profiles/remotefs/sshfs/ds920.nix
               ./profiles/shells/core.nix

--- a/profiles/graphical/ghostty.nix
+++ b/profiles/graphical/ghostty.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }: {
+  environment.systemPackages = with pkgs; [
+    ghostty
+  ];
+}

--- a/profiles/graphical/gnome.nix
+++ b/profiles/graphical/gnome.nix
@@ -8,6 +8,11 @@
     celluloid
   ];
 
+  fonts.packages = with pkgs; [
+    jetbrains-mono
+    pkgs."nerd-fonts".jetbrains-mono
+  ];
+
   services = {
     # Enable flatpak for gnome-software
     flatpak = {

--- a/users/matte.nix
+++ b/users/matte.nix
@@ -17,6 +17,7 @@ in
       imports = [
         agenix.homeManagerModules.age
         ./profiles/graphical/firefox.nix
+        ./profiles/graphical/ghostty/default.nix
         ./profiles/graphical/gnome/default.nix
         ./profiles/graphical/gnome/extensions/tiling-shell.nix
         ./profiles/graphical/gnome/variety/default.nix

--- a/users/profiles/graphical/ghostty/default.nix
+++ b/users/profiles/graphical/ghostty/default.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }: {
+  programs.ghostty = {
+    enable = true;
+    package = pkgs.ghostty;
+    enableFishIntegration = true;
+    settings = {
+      theme = "GitHub Dark High Contrast";
+      mouse-hide-while-typing = true;
+      copy-on-select = "clipboard";
+      cursor-style = "beam";
+      cursor-style-blink = true;
+      window-padding-x = 10;
+      window-padding-y = 8;
+      window-padding-balance = true;
+      window-save-state = "always";
+    };
+  };
+}

--- a/users/profiles/graphical/gnome/default.nix
+++ b/users/profiles/graphical/gnome/default.nix
@@ -17,7 +17,7 @@
 
       font-name = "Cantarell 10";
       document-font-name = "Cantarell 10";
-      monospace-font-name = "DejaVu Sans Mono 10";
+      monospace-font-name = "JetBrains Mono 10";
 
       font-antialiasing = "rgba";
       font-hinting = "full";
@@ -43,7 +43,7 @@
 
     "org/gnome/shell" = {
       favorite-apps = [
-        "org.gnome.Console.desktop"
+        "ghostty.desktop"
         "org.gnome.Nautilus.desktop"
         "firefox.desktop"
         "steam.desktop"


### PR DESCRIPTION
Adds Ghostty as the default terminal emulator with:

- System profile (`profiles/graphical/ghostty.nix`) that installs `ghostty` package
- Home-manager user profile (`users/profiles/graphical/ghostty/default.nix`) with:
  - GitHub Dark High Contrast theme
  - Fish shell integration
  - Beam cursor, auto-copy on select, balanced window padding
- JetBrains Mono installed via GNOME profile, inherited by Ghostty via GTK
- GNOME favorites updated: `ghostty.desktop` replaces `org.gnome.Console.desktop`
- GNOME monospace font set to JetBrains Mono 10

Applies to all hosts (ryzen, t14g1, game).