### PR TITLE
fix: ghostty cursor, dash icon, and add window layouts

### DIFF
--- a/users/profiles/graphical/ghostty/default.nix
+++ b/users/profiles/graphical/ghostty/default.nix
@@ -7,7 +7,7 @@
       theme = "GitHub Dark High Contrast";
       mouse-hide-while-typing = true;
       copy-on-select = "clipboard";
-      cursor-style = "beam";
+      cursor-style = "bar";
       cursor-style-blink = true;
       window-padding-x = 10;
       window-padding-y = 8;

--- a/users/profiles/graphical/gnome/default.nix
+++ b/users/profiles/graphical/gnome/default.nix
@@ -43,7 +43,7 @@
 
     "org/gnome/shell" = {
       favorite-apps = [
-        "ghostty.desktop"
+        "com.mitchellh.ghostty.desktop"
         "org.gnome.Nautilus.desktop"
         "firefox.desktop"
         "steam.desktop"

--- a/users/profiles/graphical/gnome/extensions/tiling-shell.nix
+++ b/users/profiles/graphical/gnome/extensions/tiling-shell.nix
@@ -22,7 +22,37 @@
       active-screen-edges = true;
 
       layouts-json = lib.hm.gvariant.mkString
-        ''[{"id":"3 Equal Columns","tiles":[{"x":0,"y":0,"width":0.333,"height":1,"groups":[1]},{"x":0.333,"y":0,"width":0.333,"height":1,"groups":[1,2]},{"x":0.666,"y":0,"width":0.333,"height":1,"groups":[2]}]},{"id":"2x16:9 Left + Right","tiles":[{"x":0,"y":0,"width":0.374,"height":0.5,"groups":[1,2]},{"x":0,"y":0.5,"width":0.374,"height":0.5,"groups":[1,2]},{"x":0.374,"y":0,"width":0.626,"height":1,"groups":[2,3]}]}]'';
+        ''[
+          {
+            "id": "Fullsize",
+            "tiles": [
+              { "x": 0, "y": 0, "width": 1, "height": 1, "groups": [1] }
+            ]
+          },
+          {
+            "id": "2 Equal Columns",
+            "tiles": [
+              { "x": 0, "y": 0, "width": 0.5, "height": 1, "groups": [1] },
+              { "x": 0.5, "y": 0, "width": 0.5, "height": 1, "groups": [2] }
+            ]
+          },
+          {
+            "id": "3 Equal Columns",
+            "tiles": [
+              { "x": 0, "y": 0, "width": 0.333, "height": 1, "groups": [1] },
+              { "x": 0.333, "y": 0, "width": 0.333, "height": 1, "groups": [1, 2] },
+              { "x": 0.666, "y": 0, "width": 0.333, "height": 1, "groups": [2] }
+            ]
+          },
+          {
+            "id": "2x16:9 Left + Right",
+            "tiles": [
+              { "x": 0, "y": 0, "width": 0.374, "height": 0.5, "groups": [1, 2] },
+              { "x": 0, "y": 0.5, "width": 0.374, "height": 0.5, "groups": [1, 2] },
+              { "x": 0.374, "y": 0, "width": 0.626, "height": 1, "groups": [2, 3] }
+            ]
+          }
+        ]'';
     };
 
     "org/gnome/desktop/wm/keybindings" = {


### PR DESCRIPTION
Three changes in separate commits:

1. **Fix cursor-style** — change `beam` to `bar` (ghostty's name for the I-beam cursor)
2. **Fix GNOME dash icon** — use correct desktop file ID `com.mitchellh.ghostty.desktop` instead of `ghostty.desktop`
3. **Add window layouts** — add Fullsize and 2 Equal Columns to Tiling Shell layouts, ordered: Fullsize → 2 Equal Columns → 3 Equal Columns → 2x16:9 Left + Right