### PR TITLE
chore: update all GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31
 
       - name: Configure Cachix caches
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v17
         with:
           name: mevensson-nixos-config
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Free Disk Space
-        uses: endersonmenezes/free-disk-space@v2
+        uses: endersonmenezes/free-disk-space@v3
         with:
           remove_android: false
           remove_dotnet: true
@@ -49,13 +49,13 @@ jobs:
           remove_swap: false
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31
 
       - name: Configure Cachix caches
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v17
         with:
           name: mevensson-nixos-config
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Free Disk Space
-        uses: endersonmenezes/free-disk-space@v2
+        uses: endersonmenezes/free-disk-space@v3
         with:
           remove_android: false
           remove_dotnet: true
@@ -94,13 +94,13 @@ jobs:
           remove_swap: false
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31
 
       - name: Configure Cachix caches
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v17
         with:
           name: mevensson-nixos-config
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -132,13 +132,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31
 
       - name: Configure Cachix caches
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v17
         with:
           name: mevensson-nixos-config
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -13,19 +13,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v26
+        uses: cachix/install-nix-action@v31
 
       - name: Update flake.lock
         id: update-flake-lock
-        uses: DeterminateSystems/update-flake-lock@v21
+        uses: DeterminateSystems/update-flake-lock@v28
         with:
           token: ${{ secrets.UPDATE_FLAKE_LOCK }}
 
       - name: Enable pull request automerge
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@v3.0.0
         if: ${{ steps.update-flake-lock.outputs.pull-request-number }}
         with:
           token: ${{ secrets.UPDATE_FLAKE_LOCK }}


### PR DESCRIPTION
Bumps all GitHub Actions across both workflow files to their latest releases.

**ci.yaml:**
| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v7 |
| cachix/install-nix-action | v27 | v31 |
| cachix/cachix-action | v15 | v17 |
| endersonmenezes/free-disk-space | v2 | v3 |

**update-flake-lock.yaml:**
| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v7 |
| cachix/install-nix-action | v26 | v31 |
| DeterminateSystems/update-flake-lock | v21 | v28 |
| peter-evans/enable-pull-request-automerge | v3 | v3.0.0 |