### PR TITLE
chore/state version migration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -183,11 +183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781906751,
-        "narHash": "sha256-6Ld1PqmptFtFKblE+SynhRgyBApUWcmrISetWqWHeeo=",
+        "lastModified": 1782415272,
+        "narHash": "sha256-Yt4nE/QSk1KRzOIMBK5/OOa7AH1Y0JbxNbgf5VTxQ6g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "37f21dfa5d27e71b75bacd9418b156f9265e312e",
+        "rev": "19d7472aca941c7e3d11e8a91d61be47d70c4ab5",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781422160,
-        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
+        "lastModified": 1782030356,
+        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
+        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
         "type": "github"
       },
       "original": {
@@ -329,11 +329,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781930652,
-        "narHash": "sha256-7VPaBziWHi8dJeiG9lrwunOC6rkhmgTsbUQVHCab6+U=",
+        "lastModified": 1782420382,
+        "narHash": "sha256-WrcMtWf78GsUYzXhLvNO5LXIkV1Er2HEeCvbPrRiS+I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6b4d2c6477c8e23f7ac33040849a4c1c9ad633fc",
+        "rev": "de54e81b6f7394311fda356edace0d952a8ead41",
         "type": "github"
       },
       "original": {

--- a/hosts/game/configuration.nix
+++ b/hosts/game/configuration.nix
@@ -14,6 +14,6 @@
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "24.05"; # Did you read the comment?
+  system.stateVersion = "26.05"; # Did you read the comment?
 }
 

--- a/hosts/live-installer/configuration.nix
+++ b/hosts/live-installer/configuration.nix
@@ -16,6 +16,6 @@
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "24.05"; # Did you read the comment?
+  system.stateVersion = "26.05"; # Did you read the comment?
 }
 

--- a/hosts/ryzen/configuration.nix
+++ b/hosts/ryzen/configuration.nix
@@ -14,6 +14,6 @@
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "23.05"; # Did you read the comment?
+  system.stateVersion = "26.05"; # Did you read the comment?
 }
 

--- a/hosts/t14g1/configuration.nix
+++ b/hosts/t14g1/configuration.nix
@@ -14,6 +14,6 @@
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "23.05"; # Did you read the comment?
+  system.stateVersion = "26.05"; # Did you read the comment?
 }
 

--- a/profiles/core/auto-optimize.nix
+++ b/profiles/core/auto-optimize.nix
@@ -1,11 +1,9 @@
 { ... }: {
-  nix.settings = [
+  nix.settings = {
     auto-optimise-store = true;
-  ];
-  nix.optimize = {
+  };
+  nix.optimise = {
     automatic = true;
-    dates = [
-      "03:45"
-    ];
+    dates = [ "03:45" ];
   };
 }

--- a/profiles/core/auto-upgrade.nix
+++ b/profiles/core/auto-upgrade.nix
@@ -1,9 +1,0 @@
-{ ... }: {
-  system.autoUpgrade = {
-    enable = true;
-    flake = "github:mevensson/nixos-config-new";
-    dates = "daily";
-    persistent = true;
-    randomizedDelaySec = "10m";
-  };
-}

--- a/profiles/core/default.nix
+++ b/profiles/core/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./agenix.nix
     ./auto-gc.nix
+    ./auto-optimize.nix
     ./cachix.nix
     ./fwupd.nix
     ./home-manager.nix

--- a/users/matte.nix
+++ b/users/matte.nix
@@ -49,7 +49,7 @@ in
         # You can update Home Manager without changing this value. See
         # the Home Manager release notes for a list of state version
         # changes in each release.
-        stateVersion = "22.05";
+        stateVersion = "26.05";
       };
 
       programs.git.settings.user = {

--- a/users/test.nix
+++ b/users/test.nix
@@ -30,7 +30,7 @@ in
         # You can update Home Manager without changing this value. See
         # the Home Manager release notes for a list of state version
         # changes in each release.
-        stateVersion = "22.05";
+        stateVersion = "26.05";
       };
     };
 


### PR DESCRIPTION
- **chore: remove unused auto-upgrade module**
- **fix: correct auto-optimize syntax and enable it**
- **chore: bump stateVersion to 26.05**
- **chore: update flake.lock**
