### PR TITLE
Add grill-me and grilling skills from mattpocock/skills

### DIFF
--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-me
+description: A relentless interview to sharpen a plan or design.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session.

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+Do not enact the plan until I confirm we have reached a shared understanding.


### PR DESCRIPTION
Installs Matt Pocock's `grill-me` and `grilling` agent skills in `.agents/skills/` for stress-testing plans and designs via relentless interviewing.