### PR TITLE
Add Mission Center system monitor with Vitals integration

### DIFF
--- a/profiles/graphical/gnome.nix
+++ b/profiles/graphical/gnome.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }: {
   environment.systemPackages = with pkgs; [
     gnome-tweaks
+    mission-center
 
     firmware-updater
     gnome-firmware

--- a/users/profiles/graphical/gnome/extensions/vitals.nix
+++ b/users/profiles/graphical/gnome/extensions/vitals.nix
@@ -14,6 +14,7 @@
 
     "org/gnome/shell/extensions/vitals" = {
       fixed-widths = false;
+      monitor-cmd = "missioncenter";
       hot-sensors = [
         "_processor_usage_"
         "_processor_frequency_"


### PR DESCRIPTION
Adds Mission Center (GTK4 system monitor app) to all GNOME hosts and configures the Vitals extension to open it on click instead of GNOME System Monitor.