### PR TITLE
Fix OpenCode Zen provider config

### DIFF
--- a/users/profiles/programming/opencode/deepseek-v4-flash-free.nix
+++ b/users/profiles/programming/opencode/deepseek-v4-flash-free.nix
@@ -1,5 +1,5 @@
 { lib, ... }: {
-  programs.opencode.zenModels."deepseek/deepseek-v4-flash:free" = {
+  programs.opencode.zenModels."deepseek-v4-flash-free" = {
     name = "DeepSeek V4 Flash Free (Zen)";
     tool_call = true;
     limit = {

--- a/users/profiles/programming/opencode/default.nix
+++ b/users/profiles/programming/opencode/default.nix
@@ -78,7 +78,10 @@ in
             models = cfg.remoteModels;
           };
           opencode = {
+            npm = "@ai-sdk/openai-compatible";
+            name = "OpenCode Zen";
             options = {
+              baseURL = "https://opencode.ai/zen/v1";
               apiKey = "{file:${opencodeZenApiKeyPath}}";
             };
             models = cfg.zenModels;


### PR DESCRIPTION
Fix two issues in the OpenCode Zen provider configuration:

1. **Missing SDK/endpoint config**: Added `npm`, `name`, and `baseURL` to the `opencode` provider so opencode uses the correct `@ai-sdk/openai-compatible` SDK and points at `https://opencode.ai/zen/v1`.

2. **Wrong model ID**: Changed `deepseek/deepseek-v4-flash:free` → `deepseek-v4-flash-free` to match the actual Zen API model ID. The old ID with `:` suffix was unsupported by opencode's model parser.