### PR TITLE
Remove default model from opencode config

### DIFF
--- a/users/profiles/programming/opencode/default.nix
+++ b/users/profiles/programming/opencode/default.nix
@@ -66,10 +66,7 @@ in
     home.file.".config/opencode/opencode.jsonc".text =
       builtins.toJSON {
         "$schema" = "https://opencode.ai/config.json";
-        model =
-          if hasLocalModels
-          then "llama.cpp/gemma4:12b"
-          else "openrouter/deepseek/deepseek-v4-flash";
+
         provider = {
           openrouter = {
             options = {


### PR DESCRIPTION
Removes the hardcoded default model from the generated opencode JSON config, so opencode will use its own internal default or prompt the user to select a model at runtime.